### PR TITLE
Fixes for direct deploy and SASS compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# liferay-gradle-plugin
+Liferay sdk for Gradle
+
+This plugin will also work with Liferay 6.2. The former versions caused NullpointerExceptions in the sassToCss targets.

--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ idea {
 }
 
 dependencies {
-    jacoco group: 'org.jacoco', name: 'org.jacoco.agent', version: '0.6.2.201302030002', classifier: 'runtime'
+    jacoco group: 'org.jacoco', name: 'org.jacoco.agent', version: '0.7.6.201602180812', classifier: 'runtime'
 }
 
 test {

--- a/src/main/java/com/github/jelmerk/DirectDeploy.java
+++ b/src/main/java/com/github/jelmerk/DirectDeploy.java
@@ -55,8 +55,8 @@ public class DirectDeploy extends DefaultTask {
         SecurityManager currentSecurityManager = System.getSecurityManager();
 
         SecurityManager securityManager = new SecurityManager() {
-//            public void checkPermission(Permission permission) {
-//            }
+            public void checkPermission(Permission permission) {
+            }
             public void checkExit(int status) {
                 throw new SecurityException();
             }
@@ -108,7 +108,7 @@ public class DirectDeploy extends DefaultTask {
             deploy("com.liferay.portal.tools.deploy.PortletDeployer", classLoader, args);
         }
         catch (ReflectiveOperationException e)  {
-            logger.error("Unable to execute direct deploy portlet.\n {} due to {}.", e.getMessage(), e.getCause());
+            logger.error("Unable to execute direct deploy portlet", e);
         }
     }
 
@@ -122,7 +122,7 @@ public class DirectDeploy extends DefaultTask {
             deploy("com.liferay.portal.tools.deploy.HookDeployer", classLoader, args);
         }
         catch (ReflectiveOperationException e)  {
-            logger.error("Unable to execute direct deploy hook.\n {} due to {}.", e.getMessage(), e.getCause());
+            logger.error("Unable to execute direct deploy hook.", e);
         }
     }
 
@@ -141,7 +141,7 @@ public class DirectDeploy extends DefaultTask {
             deploy("com.liferay.portal.tools.deploy.ThemeDeployer", classLoader, args);
         }
         catch (ReflectiveOperationException e)  {
-            logger.error("Unable to execute direct deploy theme.\n {} due to {}.", e.getMessage(), e.getCause());
+            logger.error("Unable to execute direct deploy theme.", e);
         }
     }
 
@@ -168,10 +168,9 @@ public class DirectDeploy extends DefaultTask {
 
         System.setProperty("deployer.app.server.type", appServerType);
         System.setProperty("deployer.base.dir", (new File(project.getBuildDir(), "libs")).getAbsolutePath());
-        System.setProperty("deployer.dest.dir", (new File(appServerDir, "webapps")).getAbsolutePath());
+        System.setProperty("deployer.dest.dir", getDestDir().getAbsolutePath());
         System.setProperty("deployer.file.pattern", warFile.getName());
-        System.setProperty("deployer.unpack.war", "true");
-
+        System.setProperty("deployer.unpack.war", String.valueOf(true));
 
         if (pluginType.equals("portlet")) {
             deployPortlet();

--- a/src/main/java/com/github/jelmerk/HookPlugin.java
+++ b/src/main/java/com/github/jelmerk/HookPlugin.java
@@ -33,5 +33,8 @@ public class HookPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPlugins().apply(LiferayBasePlugin.class);
+
+        LiferayPluginExtension liferayExtension = project.getExtensions().getByType(LiferayPluginExtension.class);
+        liferayExtension.setPluginType("hook");
     }
 }

--- a/src/main/java/com/github/jelmerk/PortletPlugin.java
+++ b/src/main/java/com/github/jelmerk/PortletPlugin.java
@@ -38,6 +38,10 @@ public class PortletPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPlugins().apply(LiferayBasePlugin.class);
+
+        LiferayPluginExtension liferayExtension = project.getExtensions().getByType(LiferayPluginExtension.class);
+        liferayExtension.setPluginType("portlet");
+
         SassCompilationPluginDelegate sassCompilationPluginDelegate = new SassCompilationPluginDelegate();
         sassCompilationPluginDelegate.doApply(project);
     }

--- a/src/main/java/com/github/jelmerk/SassToCss.java
+++ b/src/main/java/com/github/jelmerk/SassToCss.java
@@ -69,7 +69,13 @@ public class SassToCss extends DefaultTask {
         javaTask.setNewenvironment(true);
 
         javaTask.createArg()
-                .setLine("sass.dir=" + getSassDir());
+                .setLine("sass.dir=" + "/");
+
+        javaTask.createArg()
+                .setLine("sass.docroot.dir=" + getSassDir());
+
+        javaTask.createArg()
+                .setLine("sass.portal.common.dir=" + new File(getAppServerPortalDir(), "/html/css/common"));
 
         javaTask.createJvmarg().setLine("-Dliferay.lib.portal.dir=" + new File(getAppServerPortalDir(), "WEB-INF/lib"));
 

--- a/src/main/java/com/github/jelmerk/ThemePlugin.java
+++ b/src/main/java/com/github/jelmerk/ThemePlugin.java
@@ -66,6 +66,9 @@ public class ThemePlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getPlugins().apply(LiferayBasePlugin.class);
 
+        LiferayPluginExtension liferayExtension = project.getExtensions().getByType(LiferayPluginExtension.class);
+        liferayExtension.setPluginType("theme");
+
         SassCompilationPluginDelegate sassCompilationPluginDelegate = new SassCompilationPluginDelegate();
         sassCompilationPluginDelegate.doApply(project);
 

--- a/src/main/java/com/github/jelmerk/ThemePlugin.java
+++ b/src/main/java/com/github/jelmerk/ThemePlugin.java
@@ -21,17 +21,12 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.file.DuplicatesStrategy;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.plugins.WarPluginConvention;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.bundling.War;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Implementation of {@link Plugin} that adds tasks and configuration for creating Liferay themes.
@@ -79,24 +74,6 @@ public class ThemePlugin implements Plugin<Project> {
 
         configureBuildThumbnailTaskDefaults(project);
         createBuildThumbnailTask(project);
-
-        addThemeMergeToWarTask(project);
-    }
-
-    private void addThemeMergeToWarTask(Project project) {
-        MergeTheme mergeTheme = (MergeTheme) project.getTasks().getByName(MERGE_THEME_TASK_NAME);
-
-        War warTask = (War) project.getTasks().getByName(WarPlugin.WAR_TASK_NAME);
-
-        warTask.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);
-
-        Map<String, Object> args = new HashMap<String, Object>();
-        args.put("dir", mergeTheme.getOutputDir());
-        args.put("include", "**/*");
-
-        FileTree generatedSassCaches = project.fileTree(args);
-
-        warTask.from(generatedSassCaches);
     }
 
     private void createThemeExtension(Project project) {


### PR DESCRIPTION
Hi,

these are a few fixes around the direct deploy process and the SASS compilation:
 * now the selected plugin automatically sets the plugin type for the direct deploy;
 * fixed an issue with the security permissions not allowing the execution of Liferay's direct deploy classes
 * fixed the SASS compilation as now the merged theme and the webapp directory are merged before the compilation takes place
 * files from the .sass-cache directories are copied in their parent directories.